### PR TITLE
Better passthrough

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ exports.handler = async (event, context, lambdaCallback) => {
     lambdaCallback(null, response)
     return
   } catch (e) {
-    console.error(e)
     lambdaCallback(e, exports.errorResponse(e))
   }
 }
@@ -27,18 +26,18 @@ exports.queryResult = (url, testFetch) => {
   const requestHeaders = {
       method: "get",
       headers: { "Authorization": "apikey " + process.env.PRIMO_API_KEY }
-  }  
+  }
   return methodFetch(url, requestHeaders)
 }
 
 exports.createLambdaResponse = async (result) => {
   const body = await result.text()
-
   return response = {
-    statusCode: 200,
+    statusCode: result.status,
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Content-Type": result.headers.get("Content-type"),
+      "x-nd-version": process.env.VERSION,
     },
     body: body
   }
@@ -51,6 +50,7 @@ exports.errorResponse = (error) => {
     headers: {
       "Access-Control-Allow-Origin" : "*", // Required for CORS support to work
       "x-nd-version": process.env.VERSION,
+      "Content-Type": "application/json",
     },
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -6,9 +6,12 @@ describe("primo passthrough", () => {
   beforeEach(() => {
     jest.resetModules() // this is important for the process env replacement
     process.env = { ...OLD_ENV }
+    // setup relavant env variables.
     process.env.PRIMO_API_KEY = "primokey"
     process.env.PASSTHROUGH_URL = "primourl"
+    process.env.VERSION = "test"
 
+    // this resets the mocks added to the fetch mock between test runs
     fetch.resetMocks()
   })
 
@@ -23,11 +26,11 @@ describe("primo passthrough", () => {
     }
     const url = index.queryUrl(event)
 
-    // uses the passtrhough url
+    // uses the passtrhough url from env
     expect(url).toMatch(/primourl/)
-    // passes the path back to the url
+    // passes the path back to the url from the event passthrough
     expect(url).toMatch(/path/)
-    // creates a query string from all the data.
+    // creates a query string from all the data from the event queryStringParameters
     expect(url).toMatch(/\?var1%3Dvar1%26var2%3Dvar2%26var3%3Dvar3/)
   })
 
@@ -37,31 +40,51 @@ describe("primo passthrough", () => {
     const response = await index.queryResult("http://google.com", fetch)
     const headers = {
       "headers": {
-        "Authorization": "apikey primokey",
+        "Authorization": "apikey primokey", // from env
       },
       "method": "get",
     }
 
     expect(fetch).toHaveBeenCalledWith("http://google.com", headers)
-
   })
 
   test("it builds a response body from a fetched response", async () => {
-    const textFunction = jest.fn(() => Promise.resolve('body data'))
-    const headersGet = jest.fn((d) => d)
-    let result = { text: textFunction,  headers: { get: headersGet }}
+    const textFunction = jest.fn(() => Promise.resolve('body data')) // mock of the promise that gets the text of the fetched url
+    const headersGet = jest.fn((d) => d) // mock a headers function to get returns the name of the header
+    // the full mock a result from fetch that is used.s
+    let result = { text: textFunction,  headers: { get: headersGet }, status: "status"}
 
     const test = {
-      body: "body data",
+      body: "body data", // from the response.
       headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Content-Type": "Content-type"
+        "Access-Control-Allow-Origin": "*", // added implicitly
+        "Content-Type": "Content-type", // passed through from the response headers
+        "x-nd-version": "test", // passed from env
       },
-      "statusCode": 200,
+      "statusCode": "status", // passed through from the response
     }
 
     const response = await index.createLambdaResponse(result)
 
     expect(response).toEqual(test)
   })
+
+  test("it catches errors in a generic 500 error response", () => {
+    const response = (err, data) => {
+      //expect(err).toBeDefined()
+      const test = {
+        "body": "{\"error\":\"Unable to Process Request\"}",
+        "headers": {
+          "Access-Control-Allow-Origin": "*",
+          "Content-Type": "application/json",
+          "x-nd-version": "test"
+        },
+        "statusCode": 500
+      }
+      expect(data).toEqual(test)
+    }
+
+    index.handler({}, {}, response)
+  })
+
 })


### PR DESCRIPTION
Pass primo's response status through so 40Xs and 50Xs from the server reach the client instead of always calling them 200s

Update the test to annotate what they are testing and where it the data is coming from to help illuminate what is being tested.  



